### PR TITLE
Tight mode was failing for heading levels greater than 2

### DIFF
--- a/test/fixtures/tight/input.md
+++ b/test/fixtures/tight/input.md
@@ -10,4 +10,8 @@ Text.
 
 ## Something elsefi
 
+### Yet Another Thing
+
+### And another thing
+
 # Something iffi

--- a/test/fixtures/tight/output.md
+++ b/test/fixtures/tight/output.md
@@ -5,6 +5,8 @@
 -   [Something if](#something-if)
     -   [Something else](#something-else)
     -   [Something elsefi](#something-elsefi)
+        -   [Yet Another Thing](#yet-another-thing)
+        -   [And another thing](#and-another-thing)
 -   [Something iffi](#something-iffi)
 
 # Something if
@@ -14,5 +16,9 @@
 Text.
 
 ## Something elsefi
+
+### Yet Another Thing
+
+### And another thing
 
 # Something iffi


### PR DESCRIPTION
This PR updates the test case to fail with the current version of mdast-util-toc.
I've already opened a PR against mdast-util-toc to fix the issue: https://github.com/BarryThePenguin/mdast-util-toc/pull/3